### PR TITLE
Use brax.v1 instead of brax to make it work

### DIFF
--- a/diffmimic/brax_lib/acting.py
+++ b/diffmimic/brax_lib/acting.py
@@ -17,7 +17,7 @@
 import time
 from typing import Callable, Sequence, Tuple
 
-from brax import envs
+from brax.v1 import envs
 from brax.training.types import Metrics
 from brax.training.types import Policy
 from brax.training.types import PolicyParams
@@ -25,7 +25,7 @@ from brax.training.types import PRNGKey
 from brax.training.types import Transition
 import jax
 import numpy as np
-import brax
+import brax.v1 as brax
 
 
 def actor_step(

--- a/diffmimic/brax_lib/agent_diffmimic.py
+++ b/diffmimic/brax_lib/agent_diffmimic.py
@@ -19,8 +19,8 @@ import time
 from typing import Callable, Optional, Tuple
 
 from absl import logging
-from brax import envs
-from brax.envs import wrappers
+from brax.v1 import envs
+from brax.v1.envs import wrappers
 from brax.training import pmap
 from brax.training import types
 from brax.training.acme import running_statistics
@@ -28,7 +28,7 @@ from brax.training.acme import specs
 from brax.training.agents.apg import networks as apg_networks
 from brax.training.types import Params
 from brax.training.types import PRNGKey
-from brax.io import model
+from brax.v1.io import model
 import flax
 import jax
 import jax.numpy as jnp

--- a/diffmimic/mimic_envs/__init__.py
+++ b/diffmimic/mimic_envs/__init__.py
@@ -1,4 +1,4 @@
-from brax import envs
+from brax.v1 import envs
 from .humanoid_mimic import HumanoidMimic
 from .humanoid_mimic_train import HumanoidMimicTrain
 from . import pd_controller

--- a/diffmimic/mimic_envs/humanoid_mimic.py
+++ b/diffmimic/mimic_envs/humanoid_mimic.py
@@ -1,6 +1,6 @@
-import brax
-from brax import jumpy as jp
-from brax.envs import env
+import brax.v1 as brax
+from brax.v1 import jumpy as jp
+from brax.v1.envs import env
 from .system_configs import get_system_cfg
 from diffmimic.utils.io import deserialize_qp
 from .losses import *

--- a/diffmimic/mimic_envs/humanoid_mimic_train.py
+++ b/diffmimic/mimic_envs/humanoid_mimic_train.py
@@ -1,5 +1,6 @@
-from brax import jumpy as jp
-from brax.envs import env
+import brax.v1 as brax
+from brax.v1 import jumpy as jp
+from brax.v1.envs import env
 from .humanoid_mimic import HumanoidMimic
 from .losses import *
 import jax

--- a/diffmimic/mimic_envs/pd_controller.py
+++ b/diffmimic/mimic_envs/pd_controller.py
@@ -1,8 +1,8 @@
 from typing import Tuple
 
-from brax import jumpy as jp
-from brax.physics.base import P, QP
-from brax.physics.actuators import Angle
+from brax.v1 import jumpy as jp
+from brax.v1.physics.base import P, QP
+from brax.v1.physics.actuators import Angle
 
 
 def compute_pd_control(target_angles, current_angles, current_velocities, Kp, Kd):

--- a/diffmimic/mimic_envs/system_configs/__init__.py
+++ b/diffmimic/mimic_envs/system_configs/__init__.py
@@ -3,7 +3,7 @@ from .SWORDSHIELD import _SYSTEM_CONFIG_SWORDSHIELD
 from .SMPL import _SYSTEM_CONFIG_SMPL
 
 from google.protobuf import text_format
-from brax.physics.config_pb2 import Config
+from brax.v1.physics.config_pb2 import Config
 
 
 def get_system_cfg(system_type):

--- a/diffmimic/utils/io.py
+++ b/diffmimic/utils/io.py
@@ -1,6 +1,6 @@
-import brax
+import brax.v1 as brax
 import jax.numpy as jnp
-from brax import QP
+from brax.v1 import QP
 
 
 def deserialize_qp(nparray) -> brax.QP:

--- a/mimic.py
+++ b/mimic.py
@@ -3,8 +3,9 @@ import numpy as np
 import jax.numpy as jnp
 from absl import flags, app
 import yaml
-from brax import envs
-from brax.io import metrics
+import brax.v1 as brax
+from brax.v1 import envs
+from brax.v1.io import metrics
 from brax.training.agents.apg import networks as apg_networks
 from diffmimic.utils import AttrDict
 from diffmimic.mimic_envs import register_mimic_env

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-optax==0.1.3
-chex==0.1.5
-flax==0.6.1
-brax==0.0.15
+optax
+chex
+flax
+brax
 streamlit

--- a/visualize.py
+++ b/visualize.py
@@ -1,7 +1,7 @@
 import numpy as np
 import os
-from brax import envs
-from brax.io import html
+from brax.v1 import envs
+from brax.v1.io import html
 import streamlit.components.v1 as components
 import streamlit as st
 from diffmimic.utils.io import deserialize_qp, serialize_qp


### PR DESCRIPTION
Current code does not work for newer versions of JAX (and its ecosystem).
Luckly, the major culprit of the incompatibility here (brax) has a `v1` module that makes it backwards compatible.

This is not the final solution (as a rewrite would probably be better), but at least now people can run this on the current versions (and enjoy all the benefits that new jax has)

Great work BTW.

closes #6, closes #5 